### PR TITLE
release: v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.1 (2024-05-17)
+
+This minor patch provides updates to the `string_hashmap!` macro.
+
+- meta: add ["as-is" maintenance badge](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section) to `Cargo.toml`
+- docs: minor documentation example update for `string_hashmap!` macro
+- perf: `string_hashmap!` macro passed with 0 arguments will have a smaller expansion
+- perf: `string_hashmap!` macro passed with 1 or more arguments will call `HashMap::from()`. This allows for reserving memory upfront. Previously, the macro would expand to a `HashMap::new()` with multiple `insert()` calls after.
+
 ## 1.0.0 (2024-05-15)
 
 - Initial release of the `string-literals` library

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "string-literals"
-version = "1.0.0"
+version = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "string-literals"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Samantha Nguyen <contact@samanthanguyen.me>"]
 description = "Rust macros to more easily create String types"
 repository = "https://github.com/neoncitylights/string-literals"
@@ -11,3 +11,6 @@ rust-version = "1.56.0"
 keywords = ["string", "macro"]
 categories = ["development-tools"]
 include = ["src", "LICENSE-APACHE", "LICENSE-MIT"]
+
+[badges]
+maintenance.status = "as-is"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # string-literals
 
 [![License](https://img.shields.io/badge/License-MIT%20%26%20Apache%202.0-blue?style=flat-square)](#license)
-[![master docs](https://img.shields.io/github/deployments/neoncitylights/string-literals/github-pages?style=flat-square&label=master%20docs)](https://neoncitylights.github.io/string-literals/string_literals/index.html)
+[![nightly docs](https://img.shields.io/github/deployments/neoncitylights/string-literals/github-pages?style=flat-square&label=nightly%20docs)](https://neoncitylights.github.io/string-literals/string_literals/index.html)
 [![docs.rs](https://img.shields.io/docsrs/string-literals/latest?style=flat-square&label=docs.rs)](https://docs.rs/string-literals/)
 [![CI](https://img.shields.io/github/actions/workflow/status/neoncitylights/string-literals/.github/workflows/main.yml?style=flat-square)](https://github.com/neoncitylights/string-literals/actions/workflows/main.yml)
 [![Codecov](https://img.shields.io/codecov/c/github/neoncitylights/string-literals?style=flat-square&logo=codecov&logoColor=%23fff)](https://codecov.io/gh/neoncitylights/string-literals)
@@ -51,9 +51,14 @@ let new_vec = string_vec!["Banana", "Apple", "Orange"];
 use std::collections::HashMap;
 use string_literals::string_hashmap;
 
-let mut old: HashMap<String, String> = HashMap::new();
-old.insert("Banana".to_owned(), "Good".to_owned());
-old.insert("Apple".to_owned(), "Okay".to_owned());
+let mut old1: HashMap<String, String> = HashMap::new();
+old1.insert("Banana".to_owned(), "Good".to_owned());
+old1.insert("Apple".to_owned(), "Okay".to_owned());
+
+let old2: HashMap<String, String> = HashMap::from([
+    ("Banana".to_owned(), "Good".to_owned()),
+    ("Apple".to_owned(), "Okay".to_owned()),
+]);
 
 let new: HashMap<String, String> = string_hashmap! {
     "Banana" => "Good",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,14 @@ let new_vec = string_vec!["Banana", "Apple", "Orange"];
 use std::collections::HashMap;
 use string_literals::string_hashmap;
 
-let mut old: HashMap<String, String> = HashMap::new();
-old.insert("Banana".to_owned(), "Good".to_owned());
-old.insert("Apple".to_owned(), "Okay".to_owned());
+let mut old1: HashMap<String, String> = HashMap::new();
+old1.insert("Banana".to_owned(), "Good".to_owned());
+old1.insert("Apple".to_owned(), "Okay".to_owned());
+
+let old2: HashMap<String, String> = HashMap::from([
+    ("Banana".to_owned(), "Good".to_owned()),
+    ("Apple".to_owned(), "Okay".to_owned()),
+]);
 
 let new: HashMap<String, String> = string_hashmap! {
     "Banana" => "Good",
@@ -171,16 +176,11 @@ macro_rules! string_vec {
 #[macro_export]
 macro_rules! string_hashmap {
 	() => {
-		{
-			let mut _map = ::std::collections::HashMap::new();
-			_map
-		}
+		::std::collections::HashMap::new()
 	};
 	($($k:expr => $v:expr),+ $(,)?) => {
-		{
-			let mut _map = ::std::collections::HashMap::new();
-			$(_map.insert($k.to_owned(), $v.to_owned());)*
-			_map
-		}
+		::std::collections::HashMap::from([
+			$(($k.to_owned(), $v.to_owned())),+
+		])
 	};
 }


### PR DESCRIPTION
This minor patch provides updates to the `string_hashmap!` macro.

- meta: add ["as-is" maintenance badge](https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section) to `Cargo.toml`
- docs: minor documentation example update for `string_hashmap!` macro
- perf: `string_hashmap!` macro passed with 0 arguments will have a smaller expansion
- perf: `string_hashmap!` macro passed with 1 or more arguments will call `HashMap::from()`. This allows for reserving memory upfront. Previously, the macro would expand to a `HashMap::new()` with multiple `insert()` calls after.